### PR TITLE
SASL MD5 Digest auth changes

### DIFF
--- a/lib/XmppPrebind.php
+++ b/lib/XmppPrebind.php
@@ -360,7 +360,7 @@ class XmppPrebind {
 	private function sendChallengeAndBuildDigestMd5Auth(Auth_SASL_Common $auth) {
 		$challenge = $this->sendChallenge();
 
-		$authString = $auth->getResponse(self::getNodeFromJid($this->jid), $this->password, $challenge, $this->jabberHost, self::SERVICE_NAME, $this->jid);
+		$authString = $auth->getResponse(self::getNodeFromJid($this->jid), $this->password, $challenge, $this->jabberHost, self::SERVICE_NAME);
 		$this->debug($authString, 'DIGEST-MD5 Auth String');
 
 		$authString = base64_encode($authString);


### PR DESCRIPTION
I made two changes so I can share with others. On my Prosody XMPP server environment MD5 digest auth fails due to extra trailing slash on JID when no resource is provided. Also my server log points out RFC 3920 section 6.1 point 7 breach during SASL auth due to provided authzid attribute. Thanks for your work!
